### PR TITLE
Improving construction of Shell and Solid

### DIFF
--- a/include/formo/shape.h
+++ b/include/formo/shape.h
@@ -14,6 +14,7 @@ class Point;
 class Edge;
 class Face;
 class Solid;
+class Shell;
 
 class Shape {
 public:
@@ -71,6 +72,10 @@ private:
     Color clr;
     /// Open CASCADE shape
     TopoDS_Shape shp;
+
+public:
+    static Shell make_shell(const Shape & shape);
+    static Solid make_solid(const Shape & shape);
 };
 
 } // namespace formo

--- a/include/formo/solid.h
+++ b/include/formo/solid.h
@@ -8,10 +8,18 @@
 
 namespace formo {
 
+class Shell;
+
 class Solid : public Shape {
 public:
     Solid() = default;
+
     explicit Solid(const TopoDS_Solid & solid);
+
+    /// Create a solid from a shell
+    ///
+    /// @param shell Shell to create the solid from
+    explicit Solid(const Shell & shell);
 
     /// Compute the volume of the shape
     ///

--- a/python/src/formo.cpp
+++ b/python/src/formo.cpp
@@ -371,6 +371,8 @@ PYBIND11_MODULE(formo, m)
 
     py::class_<Solid, Shape>(m, "Solid")
         .def(py::init<>())
+        .def(py::init<const Shell &>(),
+            py::arg("shell"))
         .def(py::init<const TopoDS_Solid &>(),
             py::arg("solid"))
         .def("volume", &Solid::volume)

--- a/python/src/formo.cpp
+++ b/python/src/formo.cpp
@@ -339,6 +339,9 @@ PYBIND11_MODULE(formo, m)
         .def("solids", &Shape::solids)
     ;
 
+    m.def("make_shell", &Shape::make_shell);
+    m.def("make_solid", &Shape::make_solid);
+
     py::class_<Edge, Shape>(m, "Edge")
         .def(py::init<>())
         .def(py::init<const TopoDS_Edge &>(),

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -7,11 +7,14 @@
 #include "formo/edge.h"
 #include "formo/face.h"
 #include "formo/solid.h"
+#include "formo/shell.h"
+#include "formo/exception.h"
 #include "TopExp_Explorer.hxx"
 #include "TopTools_DataMapOfShapeInteger.hxx"
 #include "TopoDS.hxx"
 #include "TopoDS_Vertex.hxx"
 #include "TopoDS_Edge.hxx"
+#include "TopoDS_Shell.hxx"
 #include "TopoDS_Solid.hxx"
 #include "BRep_Tool.hxx"
 #include <vector>
@@ -147,6 +150,24 @@ Shape::solids() const
 Shape::operator TopoDS_Shape() const
 {
     return this->shp;
+}
+
+Shell
+Shape::make_shell(const Shape & shape)
+{
+    auto shl = TopoDS::Shell(shape);
+    if (shl.IsNull())
+        throw Exception("Shape is not a shell");
+    return Shell(shl);
+}
+
+Solid
+Shape::make_solid(const Shape & shape)
+{
+    auto sld = TopoDS::Solid(shape);
+    if (sld.IsNull())
+        throw Exception("Shape is not a solid");
+    return Solid(sld);
 }
 
 } // namespace formo

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -5,7 +5,7 @@
 
 namespace formo {
 
-Shell::Shell(const TopoDS_Shell & shell) : shell(shell) {}
+Shell::Shell(const TopoDS_Shell & shell) : Shape(shell), shell(shell) {}
 
 Shell::operator TopoDS_Shell() const
 {

--- a/src/solid.cpp
+++ b/src/solid.cpp
@@ -2,13 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 #include "formo/solid.h"
+#include "formo/shell.h"
+#include "formo/exception.h"
 #include "BRepBuilderAPI_MakeSolid.hxx"
 #include "GProp_GProps.hxx"
 #include "BRepGProp.hxx"
 
 namespace formo {
 
-Solid::Solid(const TopoDS_Solid & solid) : solid(solid) {}
+Solid::Solid(const TopoDS_Solid & solid) : Shape(solid), solid(solid) {}
+
+Solid::Solid(const Shell & shell)
+{
+    BRepBuilderAPI_MakeSolid mk(shell);
+    if (!mk.IsDone())
+        throw Exception("Solid was not created");
+    this->solid = mk.Solid();
+    set_shape(this->solid);
+}
 
 double
 Solid::volume() const


### PR DESCRIPTION
- Adding a `Solid` constructor that takes a `Shell` as an argument
- Adding `Shape::make_{shell|solid}` functions
