### PR TITLE
Python package version is reported via formo.__version__

### DIFF
--- a/python/src/formo.cpp
+++ b/python/src/formo.cpp
@@ -51,7 +51,7 @@ using namespace formo;
 PYBIND11_MODULE(formo, m)
 {
     m.doc() = "pybind11 plugin for formo";
-    py::setattr(m, "version", py::str(FORMO_VERSION));
+    m.attr("__version__") = FORMO_VERSION;
 
     // clang-format off
     py::class_<Color>(m, "Color")

--- a/python/src/formo/__init__.py
+++ b/python/src/formo/__init__.py
@@ -1,5 +1,7 @@
 from .formo import *
 
+__version__ = formo.__version__
+
 __all__ = [
     "ArcOfCircle",
     "Axis1",


### PR DESCRIPTION
This is standard practice for Python packages, so we should follow suit.
