### PR TITLE
Creating `Env` class to handle global library needs

### DIFF
--- a/include/formo/env.h
+++ b/include/formo/env.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Message.hxx"
+
+namespace formo {
+
+/// Environment class
+///
+/// Use at the top level (like in `main`) of the application using `formo`.
+/// @note This is a singleton
+class Env {
+private:
+    Env();
+    Env(const Env &) = delete;
+    Env & operator=(const Env &) = delete;
+    ~Env();
+
+    const opencascade::handle<Message_Messenger> & msgr;
+    const Message_SequenceOfPrinters & printers;
+
+public:
+    static Env & instance();
+};
+
+} // namespace formo

--- a/python/src/formo.cpp
+++ b/python/src/formo.cpp
@@ -18,6 +18,7 @@
 #include "formo/cylinder.h"
 #include "formo/direction.h"
 #include "formo/edge.h"
+#include "formo/env.h"
 #include "formo/exception.h"
 #include "formo/face.h"
 #include "formo/helix.h"
@@ -50,6 +51,8 @@ using namespace formo;
 
 PYBIND11_MODULE(formo, m)
 {
+    auto & env = Env::instance();
+
     m.doc() = "pybind11 plugin for formo";
     m.attr("__version__") = FORMO_VERSION;
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "formo/env.h"
+
+namespace formo {
+
+Env::Env() : msgr(Message::DefaultMessenger()), printers(msgr->Printers())
+{
+    for (int idx = 0; idx < this->printers.Size(); ++idx)
+        this->msgr->RemovePrinter(this->printers.Value(idx + 1));
+}
+
+Env::~Env()
+{
+    for (int idx = 0; idx < this->printers.Size(); ++idx)
+        this->msgr->AddPrinter(this->printers.Value(idx + 1));
+}
+
+Env &
+Env::instance()
+{
+    static Env env;
+    return env;
+}
+
+} // namespace formo

--- a/src/iges_file.cpp
+++ b/src/iges_file.cpp
@@ -4,7 +4,6 @@
 #include "formo/iges_file.h"
 #include "formo/exception.h"
 #include "IGESControl_Reader.hxx"
-#include "Message.hxx"
 #include "Standard_Handle.hxx"
 #include "TDocStd_Document.hxx"
 #include "XCAFDoc_DocumentTool.hxx"
@@ -35,11 +34,6 @@ IGESFile::read()
 void
 IGESFile::write(const std::vector<Shape> & shapes)
 {
-    auto & msgr = Message::DefaultMessenger();
-    auto & printers = msgr->Printers();
-    for (int idx = 0; idx < printers.Size(); idx++)
-        msgr->RemovePrinter(printers.Value(idx + 1));
-
     Handle(TDocStd_Document) doc = new TDocStd_Document(TCollection_ExtendedString("formo-doc"));
     auto shape_tool = XCAFDoc_DocumentTool::ShapeTool(doc->Main());
     auto color_tool = XCAFDoc_DocumentTool::ColorTool(doc->Main());
@@ -61,9 +55,6 @@ IGESFile::write(const std::vector<Shape> & shapes)
     if (writer.Transfer(doc)) {
         writer.Write(this->fname.c_str());
     }
-
-    for (int idx = 0; idx < printers.Size(); idx++)
-        msgr->AddPrinter(printers.Value(idx + 1));
 }
 
 } // namespace formo

--- a/src/step_file.cpp
+++ b/src/step_file.cpp
@@ -4,7 +4,6 @@
 #include "formo/step_file.h"
 #include "formo/exception.h"
 #include "STEPControl_Reader.hxx"
-#include "Message.hxx"
 #include "Standard_Handle.hxx"
 #include "TDocStd_Document.hxx"
 #include "XCAFDoc_DocumentTool.hxx"
@@ -34,11 +33,6 @@ STEPFile::read()
 void
 STEPFile::write(const std::vector<Shape> & shapes)
 {
-    auto & msgr = Message::DefaultMessenger();
-    auto & printers = msgr->Printers();
-    for (int idx = 0; idx < printers.Size(); idx++)
-        msgr->RemovePrinter(printers.Value(idx + 1));
-
     Handle(TDocStd_Document) doc = new TDocStd_Document(TCollection_ExtendedString("formo-doc"));
     auto shape_tool = XCAFDoc_DocumentTool::ShapeTool(doc->Main());
     auto color_tool = XCAFDoc_DocumentTool::ColorTool(doc->Main());
@@ -61,9 +55,6 @@ STEPFile::write(const std::vector<Shape> & shapes)
     if (writer.Transfer(doc, STEPControl_AsIs)) {
         writer.Write(this->fname.c_str());
     }
-
-    for (int idx = 0; idx < printers.Size(); idx++)
-        msgr->AddPrinter(printers.Value(idx + 1));
 }
 
 } // namespace formo


### PR DESCRIPTION
Currently it removes the built-in printers used by OpenCASCADE
